### PR TITLE
typescript compiler - add declaration to compiler

### DIFF
--- a/src/compilers/typescript/index.js
+++ b/src/compilers/typescript/index.js
@@ -24,6 +24,7 @@ const compileSingleFile = (file, compilerOptions, distPath) => {
 const compile = (files, distPath) => {
   const compilerOptions =  {
     module: ts.ModuleKind.CommonJS,
+    declaration: true,
     sourceMap: true,
     jsx: 'react'
   };


### PR DESCRIPTION
It's useless if we export a compiled typescript module without the .d.ts file. So I added the `declaration` property to `true`.
This is very handy, it would be great if we could read the `compilerOptions` from root project `tsconfig.json` file.