### PR TITLE
fix addBabelPrefixAndResolve

### DIFF
--- a/src/internal/getBabelOptions/index.js
+++ b/src/internal/getBabelOptions/index.js
@@ -9,11 +9,25 @@ const getBabelRc = (pathToLook) => {
 }
 
 const addBabelPrefixAndResolve = (prefixType, obj) => {
-    if (!obj.startsWith(`babel-${prefixType}`)) {
-        obj = `babel-${prefixType}-${obj}`;
-      }
+    var [scp, pkg] = obj.split('/')
+    
+    if(!pkg) {
+      pkg = scp;
+      scp = '';
+    }
 
-      return require.resolve(obj);
+    if(!scp) {
+      if (!pkg.startsWith(`babel-${prefixType}`)) {
+        obj = `babel-${prefixType}-${pkg}`;
+      }
+    } else {
+      if (scp === '@babel' && !pkg.startsWith(`${prefixType}`)) {
+        pkg = `${prefixType}-${pkg}`;
+      }
+      obj = `${scp}/${pkg}`;
+    }
+    
+    return require.resolve(obj);
 } 
 
 /**


### PR DESCRIPTION
Hi.

"@emotion/babel-preset-css-prop" breaks "getBabelOptions"
This would fix the problem with using npm scopes other than "@babel".
By the way, I know this is not the final code used in "bit.envs", where should I contribute?

Nice work by the way...

