### PR TITLE
add @babel/plugin-proposal-object-rest-spread to react compiler

### DIFF
--- a/components/compilers/react/compilers/react/.babelrc
+++ b/components/compilers/react/compilers/react/.babelrc
@@ -6,6 +6,7 @@
   "plugins": [
     "@babel/plugin-proposal-class-properties",
     "@babel/plugin-proposal-export-default-from",
-    "@babel/plugin-proposal-export-namespace-from"
+    "@babel/plugin-proposal-export-namespace-from",
+    "@babel/plugin-proposal-object-rest-spread"
   ]
 }

--- a/components/compilers/react/compilers/react/index.js
+++ b/components/compilers/react/compilers/react/index.js
@@ -3,6 +3,7 @@ require('@babel/preset-react');
 require('@babel/plugin-proposal-class-properties');
 require('@babel/plugin-proposal-export-default-from');
 require('@babel/plugin-proposal-export-namespace-from');
+require('@babel/plugin-proposal-object-rest-spread');
 
 const baseCompile = require('../../internal/babelBaseCompiler');
 const compiledFileTypes = ['js', 'jsx'];

--- a/components/compilers/react/package.json
+++ b/components/compilers/react/package.json
@@ -7,6 +7,7 @@
         "@babel/plugin-proposal-class-properties": "^7.3.4",
         "@babel/plugin-proposal-export-default-from": "^7.2.0",
         "@babel/plugin-proposal-export-namespace-from": "^7.2.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.4.4",
         "@babel/preset-env": "^7.3.4",
         "@babel/preset-react": "^7.0.0",
         "@bit/bit.envs.internal.babel-base-compiler": "file:../../internal/babel-base-compiler"


### PR DESCRIPTION
I have a project that uses this plugin and I see in npm that he have a lot of downloads so I added the plugin to react compiler.
https://www.npmjs.com/package/@babel/plugin-proposal-object-rest-spread