### PR TITLE
Update get-babel-options to load normal module

### DIFF
--- a/components/internal/get-babel-options/index.js
+++ b/components/internal/get-babel-options/index.js
@@ -9,23 +9,26 @@ const getBabelRc = (pathToLook) => {
 
 const moduleIsAvailable = (modulePath) => {
     try {
-        require.resolve(modulePath);
-        return true;
+        return require.resolve(modulePath);;
     } catch (e) {
         return false;
     }
 }
 
 const addBabelPrefixAndResolve = (prefixType, obj) => {
-    if (moduleIsAvailable(obj)) {
-        return require.resolve(obj);
-    } else if (obj.startsWith('@babel/')) {
+    const moduleIsExist = moduleIsAvailable(obj);
+    if (moduleIsExist) {
+        return moduleIsExist;
+    }
+    if (obj.startsWith('@babel/')) {
         if (!obj.startsWith(`@babel/${prefixType}`)) {
-            return require.resolve(`@babel/${prefixType}-${obj}`);
+            obj = `@babel/${prefixType}-${obj}`;
         }
     } else if (!obj.startsWith(`babel-${prefixType}`)) {
-        return require.resolve(`babel-${prefixType}-${obj}`);
+        obj = `babel-${prefixType}-${obj}`;
     }
+
+    return require.resolve(obj);
 }
 
 /**

--- a/components/internal/get-babel-options/index.js
+++ b/components/internal/get-babel-options/index.js
@@ -16,9 +16,9 @@ const moduleIsAvailable = (modulePath) => {
 }
 
 const addBabelPrefixAndResolve = (prefixType, obj) => {
-    const moduleIsExist = moduleIsAvailable(obj);
-    if (moduleIsExist) {
-        return moduleIsExist;
+    const resolvedModule = moduleIsAvailable(obj);
+    if (resolvedModule) {
+        return resolvedModule;
     }
     if (obj.startsWith('@babel/')) {
         if (!obj.startsWith(`@babel/${prefixType}`)) {

--- a/components/internal/get-babel-options/index.js
+++ b/components/internal/get-babel-options/index.js
@@ -7,16 +7,25 @@ const getBabelRc = (pathToLook) => {
     return JSON.parse(file);
 }
 
+const moduleIsAvailable = (modulePath) => {
+    try {
+        require.resolve(modulePath);
+        return true;
+    } catch (e) {
+        return false;
+    }
+}
+
 const addBabelPrefixAndResolve = (prefixType, obj) => {
-    if (obj.startsWith('@babel/')) {
+    if (moduleIsAvailable(obj)) {
+        return require.resolve(obj);
+    } else if (obj.startsWith('@babel/')) {
         if (!obj.startsWith(`@babel/${prefixType}`)) {
-            obj = `@babel/${prefixType}-${obj}`;
+            return require.resolve(`@babel/${prefixType}-${obj}`);
         }
     } else if (!obj.startsWith(`babel-${prefixType}`)) {
-        obj = `babel-${prefixType}-${obj}`;
+        return require.resolve(`babel-${prefixType}-${obj}`);
     }
-
-    return require.resolve(obj);
 }
 
 /**


### PR DESCRIPTION
I update the addBabelPrefixAndResolve function to not return resolved filename with the wrong prefix.
For example, I tried to load a module that starts with:  
`@vue/...`  
and the function return  
`babel-helpers-@vue/...`  
so now I fixed this and the function returns `@vue/...`.